### PR TITLE
Use v-text instead of interpolation (problems with custom delimiters)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ exports.install = function (Vue, options={}) {
     options = Object.assign({}, defaultOptions, options)
 
     Vue.component('chartist', {
-        template:'<div v-el:chart :class="[ratio, noData]">{{message}}</div>',
+        template:'<div v-el:chart :class="[ratio, noData]" v-text="message"></div>',
         ready() {
             this.draw()
         },


### PR DESCRIPTION
Thank you for the great vue plugin. I just realized a small problem when using custom delimiters for string interpolation: We have django templates, so we can't use `{{x}}` in Vue, and now the `{{message}}` interpolation is not working.

I created a small pull-request using `v-text` instead. Would very much appreciate if you could accept this (this would probably help all the laravel/blade template engine users out there as well).