### PR TITLE
update of redraw function in 'options' watcher

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,13 +59,17 @@ exports.install = function (Vue, options={}) {
                         }))
                     )
             },
-            redraw() {
+            redraw(newValue, oldValue) {
+                if (JSON.stringify(newValue) === JSON.stringify(oldValue)) {
+                  return
+                }
                 if (this.error.onError) return this.draw()
                 if (this.haveNoData()) return this.setNoData()
                 this.clear()
                 this.chart.update(this.data, this.options)
             },
             resetEventHandlers(eventHandlers, oldEventHanlers) {
+                if (!this.chart) return
                 for (let item of oldEventHanlers)
                     this.chart.off(item.event, item.fn)
                 for (let item of eventHandlers)
@@ -84,7 +88,7 @@ exports.install = function (Vue, options={}) {
         },
         watch: {
             'ratio': 'redraw',
-            'options': 'draw',
+            'options': 'redraw',
             'data': { handler: 'redraw', deep: true },
             'type': 'draw',
             'eventHandlers': 'resetEventHandlers'


### PR DESCRIPTION
**[Problem]:** the watcher on 'options' triggered unnecessary updates
**[Solution]:** changed the watcher function 'draw()' to be 'redraw()' and added a condition that compares if there were any changes in the watches value, if not, it doesn't trigger an update

**[Problem]:** resetEventHandlers was producing an error: 
`TypeError: Cannot read property 'off' of null at VueComponent.resetEventHandlers`
**[Solution]:** added a guard condition that checks whether this.chart has been already initialized
