### PR TITLE
Add slot to render function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -129,13 +129,15 @@ exports.install = function (Vue, options = {}) {
       }
     },
     render (h) {
+      const children = this.message ? this.message : (this.$slots.default || []);
+
       return h('div', {
         ref: 'chart',
         'class': [
           this.ratio,
           { [this.classNoData]: this.noData }
         ]
-      }, this.message)
+      }, children)
     }
   })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,7 @@ exports.install = function (Vue, options = {}) {
       }
     },
     render (h) {
-      const children = this.message ? this.message : (this.$slots.default || []);
+      const children = this.message || this.$slots.default || [];
 
       return h('div', {
         ref: 'chart',


### PR DESCRIPTION
Standard Chartist allows to put elements inside the root div (the one with `class="ct-chart"`).
Using that I was able to put some (absolutely positioned) numbers inside the donut.

We can allow that by passing slots to the render function.